### PR TITLE
Added ability to set nodeSelector and serviceAccountName on the pod

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,8 +39,7 @@ type runOptions struct {
 	Includes  []string
 	Excludes  []string
 	ServiceAccountName string
-	NodeSelectorKeys []string
-	NodeSelectorValues []string
+	NodeSelector map[string]string
 }
 
 var configFlags = genericclioptions.NewConfigFlags()
@@ -104,19 +103,8 @@ along with the synchronized files.`,
 
 		c := kubectl.NewClient(config)
 
-		nodeSelectors := make(map[string]string)
-		if len(opt.NodeSelectorKeys) > 0 {
-			if len(opt.NodeSelectorKeys) != len(opt.NodeSelectorValues) {
-				fmt.Fprintln(stderr, "Node selector keys and values don't match, dropping node selector. %d != %d", len(opt.NodeSelectorKeys), len(opt.NodeSelectorValues))
-			} else {
-				for index, value := range opt.NodeSelectorKeys {
-					nodeSelectors[value] = opt.NodeSelectorValues[index]
-				}
-			}
-		}
-
 		fmt.Fprintln(stderr, "Create the Pod")
-		_, err = c.CreatePod(ns, name, opt.Image, cmd, workDir, opt.TTY, opt.Stdin, publicKey, opt.ServiceAccountName, nodeSelectors)
+		_, err = c.CreatePod(ns, name, opt.Image, cmd, workDir, opt.TTY, opt.Stdin, publicKey, opt.ServiceAccountName, opt.NodeSelector)
 		if err != nil {
 			return err
 		}
@@ -203,8 +191,7 @@ func init() {
 	rootCmd.Flags().StringSliceVar(&opt.Includes, "include", []string{}, "Include only specific paths from current directory for syncing")
 	rootCmd.Flags().StringSliceVar(&opt.Excludes, "exclude", []string{}, "Exclude only specific paths from current directory for syncing")
 	rootCmd.Flags().StringVar(&opt.ServiceAccountName, "service-account-name", opt.ServiceAccountName, "The service account name that you want the pod to use")
-	rootCmd.Flags().StringSliceVar(&opt.NodeSelectorKeys, "node-selector-keys", []string{}, "The node selector keys that you want applied")
-	rootCmd.Flags().StringSliceVar(&opt.NodeSelectorValues, "node-selector-values", []string{}, "The node selector values that you want applied")
+	rootCmd.Flags().StringToStringVar(&opt.NodeSelector, "node-selector", map[string]string{}, "The kay-value pairs used for the nodeSelector")
 }
 
 // Execute run the root command

--- a/pkg/kubectl/client.go
+++ b/pkg/kubectl/client.go
@@ -60,7 +60,7 @@ func (c *Client) findPodByName(namespace, name string) (*apiv1.Pod, error) {
 	return &apiv1.Pod{}, ErrWithMessagef(ErrNotFound, "Pod with name %s not found", name)
 }
 
-func (c *Client) CreatePod(namespace, name, image string, cmd []string, workDir string, tty, stdin bool, publicKey []byte) (*apiv1.Pod, error) {
+func (c *Client) CreatePod(namespace, name, image string, cmd []string, workDir string, tty, stdin bool, publicKey []byte, scvAccName string, nodeSelectors map[string]string) (*apiv1.Pod, error) {
 	if err := c.createSSHSecret(namespace, name, publicKey); err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (c *Client) CreatePod(namespace, name, image string, cmd []string, workDir 
 		return nil, err
 	}
 
-	return client.Create(createPodManifest(name, image, cmd, workDir, tty, stdin))
+	return client.Create(createPodManifest(name, image, cmd, workDir, tty, stdin, scvAccName, nodeSelectors))
 }
 
 // WaitForPod watches the given pod until the exitCondition is true

--- a/pkg/kubectl/manifest.go
+++ b/pkg/kubectl/manifest.go
@@ -19,7 +19,7 @@ func createSecretManifest(name string, publicKey []byte) *apiv1.Secret {
 	}
 }
 
-func createPodManifest(name, image string, cmd []string, workDir string, tty, stdin bool) *apiv1.Pod {
+func createPodManifest(name, image string, cmd []string, workDir string, tty, stdin bool, svcAccName string, nodeSelectors map[string]string) *apiv1.Pod {
 	syncContainer := apiv1.Container{
 		Name:  "sync",
 		Image: "ernoaapa/sshd-rsync",
@@ -65,6 +65,7 @@ func createPodManifest(name, image string, cmd []string, workDir string, tty, st
 		Stdin:      stdin,
 		StdinOnce:  stdin,
 		WorkingDir: workDir,
+
 		VolumeMounts: []apiv1.VolumeMount{
 			{
 				Name:      "workdir",
@@ -76,9 +77,12 @@ func createPodManifest(name, image string, cmd []string, workDir string, tty, st
 	return &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+
 		},
 		Spec: apiv1.PodSpec{
+			ServiceAccountName: svcAccName,
 			RestartPolicy: apiv1.RestartPolicyNever,
+			NodeSelector: nodeSelectors,
 			InitContainers: []apiv1.Container{
 				{
 					Name:  "sync-init",


### PR DESCRIPTION
- Added the ability to set a service account name using the `--service-account-name` flag.
- Added the ability to set node selectors using the `--node-selector` flag.